### PR TITLE
CEV-11121 Incorrect print in job details , when running utility step …

### DIFF
--- a/src/main/resources/project/procedures/decommissionEnvironments/tearDownEnvironments.pl
+++ b/src/main/resources/project/procedures/decommissionEnvironments/tearDownEnvironments.pl
@@ -46,7 +46,8 @@ if ( $envList ne '' ) {
         my ($envProjectName, $envName) = (trim($1), trim($2));
 
         if($envProjectName eq '' or $envName eq '') {
-            printf "Skipping incorrect environment path: '$environment'\n";
+            printf "WARNING: Incorrect environment path specified: '$environment', skipping\n";
+            next;
         }
 
         print "Tearing down environment: '$envName' in project: '$envProjectName'\n";

--- a/src/main/resources/project/project.xml
+++ b/src/main/resources/project/project.xml
@@ -538,6 +538,7 @@
             <errorHandling>failProcedure</errorHandling>
             <exclusiveMode>none</exclusiveMode>
             <parallel>0</parallel>
+            <postProcessor>postp</postProcessor>
             <releaseMode>none</releaseMode>
             <shell>ec-perl</shell>
             <timeLimitUnits>minutes</timeLimitUnits>


### PR DESCRIPTION
…with env list which has incorrect value after correct
- Skip tearDown call when incorrect env path specified
- Output postp warning when incorrect env path specified
