### PR TITLE
EFUTILITIE-13 - Removed service name default

### DIFF
--- a/src/main/resources/project/parameterForms/CreateSnapshot.xml
+++ b/src/main/resources/project/parameterForms/CreateSnapshot.xml
@@ -21,7 +21,7 @@
         <type>entry</type>
         <label>Application Name:</label>
         <property>ApplicationName</property>
-        <documentation>Name of the application for the snapshot. Either application name or service name should be provided.</documentation>
+        <documentation>Name of the application for the snapshot. Either this parameter or the service name parameter should be provided.</documentation>
         <required>0</required>
         <value>$[/myApplication/applicationName]</value>
     </formElement>
@@ -29,9 +29,8 @@
         <type>entry</type>
         <label>Service Name:</label>
         <property>ServiceName</property>
-        <documentation>Name of the service for the snapshot. Either application name or service name should be provided.</documentation>
+        <documentation>Name of the service for the snapshot. Either this parameter or the application name parameter should be provided.</documentation>
         <required>0</required>
-        <value>$[/myService/serviceName]</value>
     </formElement>
 
     <formElement>

--- a/src/main/resources/project/project.xml
+++ b/src/main/resources/project/project.xml
@@ -411,7 +411,7 @@
       </formalParameter>
       <formalParameter>
         <formalParameterName>ServiceName</formalParameterName>
-        <defaultValue>$[/myService/serviceName]</defaultValue>
+        <defaultValue/>
         <description>Name of the service for which the snapshot needs to be created.</description>
         <expansionDeferred>0</expansionDeferred>
         <required>0</required>


### PR DESCRIPTION
Having the ServiceName parameter default value in CreateSnapshot procedure caused error at runtime when trying to create application snapshot.  
Setting two conflicting default values when only one is allowed is *not* how defaults are meant to be used. Removed the service name default so now the defaults presented by the procedure will work as defaults for an application snapshot. 